### PR TITLE
Add fork logic for ePBS

### DIFF
--- a/specs/_features/epbs/fork.md
+++ b/specs/_features/epbs/fork.md
@@ -1,0 +1,133 @@
+# ePBS -- Fork Logic
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+- [Helper functions](#helper-functions)
+  - [Misc](#misc)
+    - [Modified `compute_fork_version`](#modified-compute_fork_version)
+- [Fork to EPBS](#fork-to-epbs)
+  - [Fork trigger](#fork-trigger)
+  - [Upgrading the state](#upgrading-the-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+This document describes the process of the ePBS upgrade.
+
+## Configuration
+
+Warning: this configuration is not definitive.
+
+| Name                | Value |
+|---------------------| - |
+| `EPBS_FORK_VERSION` | `Version('0x05000000')` |
+| `EPBS_FORK_EPOCH`   | `Epoch(18446744073709551615)` **TBD** |
+
+## Helper functions
+
+### Misc
+
+#### Modified `compute_fork_version`
+
+```python
+def compute_fork_version(epoch: Epoch) -> Version:
+    """
+    Return the fork version at the given ``epoch``.
+    """
+    if epoch >= EPBS_FORK_EPOCH:
+        return EPBS_FORK_VERSION
+    if epoch >= DENEB_FORK_EPOCH:
+        return DENEB_FORK_VERSION
+    if epoch >= CAPELLA_FORK_EPOCH:
+        return CAPELLA_FORK_VERSION
+    if epoch >= BELLATRIX_FORK_EPOCH:
+        return BELLATRIX_FORK_VERSION
+    if epoch >= ALTAIR_FORK_EPOCH:
+        return ALTAIR_FORK_VERSION
+    return GENESIS_FORK_VERSION
+```
+
+## Fork to EPBS
+
+### Fork trigger
+
+TBD. This fork is defined for testing purposes, the EIP may be combined with other 
+consensus-layer upgrade.
+For now, we assume the condition will be triggered at epoch `EPBS_FORK_EPOCH`.
+
+### Upgrading the state
+
+If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == EPBS_FORK_EPOCH`,
+an irregular state change is made to upgrade to ePBS.
+
+```python
+def upgrade_to_epbs(pre: deneb.BeaconState) -> BeaconState:
+    epoch = deneb.get_current_epoch(pre)
+
+    post = BeaconState(
+        # Versioning
+        genesis_time=pre.genesis_time,
+        genesis_validators_root=pre.genesis_validators_root,
+        slot=pre.slot,
+        fork=Fork(
+            previous_version=pre.fork.current_version,
+            current_version=EPBS_FORK_EPOCH,  # [Modified in ePBS]
+            epoch=epoch,
+        ),
+        # History
+        latest_block_header=pre.latest_block_header,
+        block_roots=pre.block_roots,
+        state_roots=pre.state_roots,
+        historical_roots=pre.historical_roots,
+        # Eth1
+        eth1_data=pre.eth1_data,
+        eth1_data_votes=pre.eth1_data_votes,
+        eth1_deposit_index=pre.eth1_deposit_index,
+        # Registry
+        validators=pre.validators,
+        balances=pre.balances,
+        # Randomness
+        randao_mixes=pre.randao_mixes,
+        # Slashings
+        slashings=pre.slashings,
+        # Participation
+        previous_epoch_participation=pre.previous_epoch_participation,
+        current_epoch_participation=pre.current_epoch_participation,
+        # Finality
+        justification_bits=pre.justification_bits,
+        previous_justified_checkpoint=pre.previous_justified_checkpoint,
+        current_justified_checkpoint=pre.current_justified_checkpoint,
+        finalized_checkpoint=pre.finalized_checkpoint,
+        # Inactivity
+        inactivity_scores=pre.inactivity_scores,
+        # Sync
+        current_sync_committee=pre.current_sync_committee,
+        next_sync_committee=pre.next_sync_committee,
+        # Execution-layer
+        # Withdrawals
+        next_withdrawal_index=pre.next_withdrawal_index,
+        next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
+        # Deep history valid from Capella onwards
+        historical_summaries=pre.historical_summaries,
+        # ePBS
+        previous_inclusion_list_proposer=get_beacon_proposer_index(pre), # [New in ePBS]
+        previous_inclusion_list_slot=pre.slot, # [New in ePBS]
+        latest_inclusion_list_proposer=0, # [New in ePBS]
+        latest_inclusion_list_slot=0, # [New in ePBS]
+        latest_block_hash=Hash32(), # [New in ePBS]
+        latest_full_slot=0, # [New in ePBS]
+        execution_payload_header=ExecutionPayloadHeader(), # [New in ePBS]
+        last_withdrawals_root=Root(), # [New in ePBS]
+    )
+
+    return post
+```
+

--- a/specs/_features/epbs/fork.md
+++ b/specs/_features/epbs/fork.md
@@ -123,7 +123,7 @@ def upgrade_to_epbs(pre: deneb.BeaconState) -> BeaconState:
         latest_inclusion_list_proposer=0, # [New in ePBS]
         latest_inclusion_list_slot=0, # [New in ePBS]
         latest_block_hash=Hash32(), # [New in ePBS]
-        latest_full_slot=0, # [New in ePBS]
+        latest_full_slot=pre.slot, # [New in ePBS]
         execution_payload_header=ExecutionPayloadHeader(), # [New in ePBS]
         last_withdrawals_root=Root(), # [New in ePBS]
     )


### PR DESCRIPTION
We need to review the case of how the inclusion list import restriction is handled at the first slot of the ePBS fork epoch.