### PR TITLE
Rename ePBS `execution_payload_header` -> `execution_payload_bid`

### DIFF
--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -16,45 +16,45 @@ This is an accompanying document which describes the expected actions of a "buil
 
 ## Introduction
 
-With the EIP-7732 Fork, the protocol includes new staked participants of the protocol called *Builders*. While Builders are a subset of the validator set, they have extra attributions that are optional. Validators may opt to not be builders and as such we collect the set of guidelines for those validators that want to act as builders in this document. 
+With the EIP-7732 Fork, the protocol includes new staked participants of the protocol called *Builders*. While Builders are a subset of the validator set, they have extra attributions that are optional. Validators may opt to not be builders and as such we collect the set of guidelines for those validators that want to act as builders in this document.
 
 ## Builders attributions
 
-Builders can submit bids to produce execution payloads. They can broadcast these bids in the form of `SignedExecutionPayloadHeader` objects, these objects encode a commitment to reveal an execution payload in exchange for a payment. When their bids are chosen by the corresponding proposer, builders are expected to broadcast an accompanying `SignedExecutionPayloadEnvelope` object honoring the commitment. 
+Builders can submit bids to produce execution payloads. They can broadcast these bids in the form of `SignedExecutionPayloadBid` objects, these objects encode a commitment to reveal an execution payload in exchange for a payment. When their bids are chosen by the corresponding proposer, builders are expected to broadcast an accompanying `SignedExecutionPayloadEnvelope` object honoring the commitment.
 
-Thus, builders tasks are divided in two, submitting bids, and submitting payloads. 
+Thus, builders tasks are divided in two, submitting bids, and submitting payloads.
 
 ### Constructing the payload bid
 
-Builders can broadcast a payload bid for the current or the next slot's proposer to include. They produce a `SignedExecutionPayloadHeader` as follows. 
+Builders can broadcast a payload bid for the current or the next slot's proposer to include. They produce a `SignedExecutionPayloadBid` as follows.
 
-1. Set `header.parent_block_hash` to the current head of the execution chain (this can be obtained from the beacon state as `state.last_block_hash`).
-2. Set `header.parent_block_root` to be the head of the consensus chain (this can be obtained from the beacon state as `hash_tree_root(state.latest_block_header)`. The `parent_block_root` and `parent_block_hash` must be compatible, in the sense that they both should come from the same `state` by the method described in this and the previous point. 
+1. Set `bid.parent_block_hash` to the current head of the execution chain (this can be obtained from the beacon state as `state.last_block_hash`).
+2. Set `bid.parent_block_root` to be the head of the consensus chain (this can be obtained from the beacon state as `hash_tree_root(state.latest_block_header`). The `parent_block_root` and `parent_block_hash` must be compatible, in the sense that they both should come from the same `state` by the method described in this and the previous point.
 3. Construct an execution payload. This can be performed with an external execution engine with a call to `engine_getPayloadV4`.
-4. Set `header.block_hash` to be the block hash of the constructed payload, that is `payload.block_hash`.
-5. Set `header.gas_limit` to be the gas limit of the constructed payload, that is `payload.gas_limit`.
-6. Set `header.builder_index` to be the validator index of the builder performing these actions.
-7. Set `header.slot`  to be the slot for which this bid is aimed. This slot **MUST** be either the current slot or the next slot.
-8. Set `header.value` to be the value that the builder will pay the proposer if the bid is accepted. The builder **MUST** have balance enough to fulfill this bid.
-9. Set `header.kzg_commitments_root` to be the `hash_tree_root`  of the `blobsbundle.commitments`  field returned by `engine_getPayloadV4`.
+4. Set `bid.block_hash` to be the block hash of the constructed payload, that is `payload.block_hash`.
+5. Set `bid.gas_limit` to be the gas limit of the constructed payload, that is `payload.gas_limit`.
+6. Set `bid.builder_index` to be the validator index of the builder performing these actions.
+7. Set `bid.slot`  to be the slot for which this bid is aimed. This slot **MUST** be either the current slot or the next slot.
+8. Set `bid.value` to be the value that the builder will pay the proposer if the bid is accepted. The builder **MUST** have balance enough to fulfill this bid.
+9. Set `bid.kzg_commitments_root` to be the `hash_tree_root`  of the `blobsbundle.commitments`  field returned by `engine_getPayloadV4`.
 
-After building the `header`, the builder obtains a `signature` of the header by using
+After building the `bid`, the builder obtains a `signature` of the bid by using
 
 ```python
-def get_execution_payload_header_signature(
-        state: BeaconState, header: ExecutionPayloadHeader, privkey: int) -> BLSSignature:
-    domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(header.slot))
-    signing_root = compute_signing_root(header, domain)
+def get_execution_payload_bid_signature(
+        state: BeaconState, bid: ExecutionPayloadBid, privkey: int) -> BLSSignature:
+    domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(bid.slot))
+    signing_root = compute_signing_root(bid, domain)
     return bls.Sign(privkey, signing_root)
 ```
 
-The builder assembles then `signed_execution_payload_header = SignedExecutionPayloadHeader(message=header, signature=signature)` and broadcasts it on the `execution_payload_header` global gossip topic. 
+The builder assembles then `signed_execution_payload_bid = SignedExecutionPayloadBid(message=bid, signature=signature)` and broadcasts it on the `execution_payload_bid` global gossip topic.
 
 ### Constructing the `BlobSidecar`s
 
 [Modified in EIP-7732]
 
-The `BlobSidecar` container is modified indirectly because the constant `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` is modified. The function `get_blob_sidecars` is modified because the KZG commitments are no longer included in the beacon block but rather in the `ExecutionPayloadEnvelope`, the builder has to send the commitments as parameters to this function. 
+The `BlobSidecar` container is modified indirectly because the constant `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` is modified. The function `get_blob_sidecars` is modified because the KZG commitments are no longer included in the beacon block but rather in the `ExecutionPayloadEnvelope`, the builder has to send the commitments as parameters to this function.
 
 ```python
 def get_blob_sidecars(signed_block: SignedBeaconBlock,
@@ -80,7 +80,7 @@ def get_blob_sidecars(signed_block: SignedBeaconBlock,
             block.body,
             get_generalized_index(
                 BeaconBlockBody,
-                "signed_execution_payload_header",
+                "signed_execution_payload_bid",
                 "message",
                 "blob_kzg_commitments_root",
             ),
@@ -100,19 +100,19 @@ def get_blob_sidecars(signed_block: SignedBeaconBlock,
 
 ### Constructing the execution payload envelope
 
-When the proposer publishes a valid `SignedBeaconBlock` containing a signed commitment by the builder, the builder is later expected to broadcast the corresponding `SignedExecutionPayloadEnvelope`  that fulfills this commitment. See below for a special case of an *honestly withheld payload*. 
+When the proposer publishes a valid `SignedBeaconBlock` containing a signed commitment by the builder, the builder is later expected to broadcast the corresponding `SignedExecutionPayloadEnvelope`  that fulfills this commitment. See below for a special case of an *honestly withheld payload*.
 
-To construct the `execution_payload_envelope` the builder must perform the following steps, we alias `header` to be the committed `ExecutionPayloadHeader` in the beacon block. 
+To construct the `execution_payload_envelope` the builder must perform the following steps, we alias `bid` to be the committed `ExecutionPayloadBid` in the beacon block.
 
-1. Set the `payload` field to be the `ExecutionPayload` constructed when creating the corresponding bid. This payload **MUST** have the same block hash as `header.block_hash`. 
-2. Set the `builder_index` field to be the validator index of the builder performing these steps. This field **MUST** be `header.builder_index`. 
+1. Set the `payload` field to be the `ExecutionPayload` constructed when creating the corresponding bid. This payload **MUST** have the same block hash as `bid.block_hash`.
+2. Set the `builder_index` field to be the validator index of the builder performing these steps. This field **MUST** be `bid.builder_index`.
 3. Set `beacon_block_root` to be the `hash_tree_root` of the corresponding beacon block.
-4. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle constructed when constructing the bid. This field **MUST** have a `hash_tree_root` equal to `header.blob_kzg_commitments_root`.
+4. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle constructed when constructing the bid. This field **MUST** have a `hash_tree_root` equal to `bid.blob_kzg_commitments_root`.
 5. Set `payload_witheld` to `False`.
 
 After setting these parameters, the builder should run `process_execution_payload(state, signed_envelope, verify=False)` and this function should not trigger an exception.
 
-6. Set `state_root` to `hash_tree_root(state)`. 
+6. Set `state_root` to `hash_tree_root(state)`.
 After preparing the `envelope` the builder should sign the envelope using:
 ```python
 def get_execution_payload_envelope_signature(
@@ -121,8 +121,8 @@ def get_execution_payload_envelope_signature(
     signing_root = compute_signing_root(envelope, domain)
     return bls.Sign(privkey, signing_root)
 ```
-The builder assembles then `signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=signature)` and broadcasts it on the `execution_payload` global gossip topic. 
+The builder assembles then `signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=signature)` and broadcasts it on the `execution_payload` global gossip topic.
 
 ### Honest payload withheld messages
 
-An honest builder that has seen a `SignedBeaconBlock` referencing his signed bid, but that block was not timely and thus it is not the head of the builder's chain, may choose to withhold their execution payload. For this the builder should simply act as if it were building an empty payload, without any transactions, withdrawals, etc. The `payload.block_hash` may not be equal to `header.block_hash`. The builder may then sets `payload_withheld` to `True`. If the PTC sees this message and votes for it, validators will attribute a *withholding boost* to the builder, which would increase the forkchoice weight of the parent block, favoring it and preventing the builder from being charged for the bid by not revealing. 
+An honest builder that has seen a `SignedBeaconBlock` referencing his signed bid, but that block was not timely and thus it is not the head of the builder's chain, may choose to withhold their execution payload. For this the builder should simply act as if it were building an empty payload, without any transactions, withdrawals, etc. The `payload.block_hash` may not be equal to `bid.block_hash`. The builder may then set `payload_withheld` to `True`. If the PTC sees this message and votes for it, validators will attribute a *withholding boost* to the builder, which would increase the forkchoice weight of the parent block, favoring it and preventing the builder from being charged for the bid by not revealing.

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -45,15 +45,15 @@ This is the modification of the fork choice accompanying the EIP-7732 upgrade.
 
 | Name                 | Value       |
 | -------------------- | ----------- |
-| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE / 2` (=`uint64(256)`) | 
+| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE / 2` (=`uint64(256)`) |
 | `INTERVALS_PER_SLOT` | `4` # [modified in EIP-7732] |
-| `PROPOSER_SCORE_BOOST` | `20` # [modified in EIP-7732] | 
-| `PAYLOAD_WITHHOLD_BOOST` | `40` | 
-| `PAYLOAD_REVEAL_BOOST` | `40` | 
+| `PROPOSER_SCORE_BOOST` | `20` # [modified in EIP-7732] |
+| `PAYLOAD_WITHHOLD_BOOST` | `40` |
+| `PAYLOAD_REVEAL_BOOST` | `40` |
 
 ## Containers
 
-### New `ChildNode` 
+### New `ChildNode`
 Auxiliary class to consider `(block, slot, bool)` LMD voting
 
 ```python
@@ -76,7 +76,7 @@ class LatestMessage(object):
 ```
 
 ### Modified `update_latest_messages`
-**Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`. 
+**Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
 
 ```python
 def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation) -> None:
@@ -88,8 +88,8 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
             store.latest_messages[i] = LatestMessage(slot=slot, root=beacon_block_root)
 ```
 
-### Modified `Store` 
-**Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain. 
+### Modified `Store`
+**Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
 
 ```python
 @dataclass
@@ -115,7 +115,7 @@ class Store(object):
     ptc_vote: Dict[Root, Vector[uint8, PTC_SIZE]] = field(default_factory=dict)  # [New in EIP-7732]
 ```
 
-### Modified `get_forkchoice_store` 
+### Modified `get_forkchoice_store`
 
 ```python
 def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
@@ -163,8 +163,8 @@ def notify_ptc_messages(store: Store, state: BeaconState, payload_attestations: 
                 store,
                 PayloadAttestationMessage(
                     validator_index=idx,
-                    data=payload_attestation.data, 
-                    signature=BLSSignature(), 
+                    data=payload_attestation.data,
+                    signature=BLSSignature(),
                     is_from_block=True
                 )
             )
@@ -175,7 +175,7 @@ def notify_ptc_messages(store: Store, state: BeaconState, payload_attestations: 
 ```python
 def is_payload_present(store: Store, beacon_block_root: Root) -> bool:
     """
-    Return whether the execution payload for the beacon block with root ``beacon_block_root`` was voted as present 
+    Return whether the execution payload for the beacon block with root ``beacon_block_root`` was voted as present
     by the PTC
     """
     # The beacon block root must be known
@@ -188,20 +188,20 @@ def is_payload_present(store: Store, beacon_block_root: Root) -> bool:
 ```python
 def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
     parent = store.blocks[block.parent_root]
-    parent_block_hash = block.body.signed_execution_payload_header.message.parent_block_hash
-    message_block_hash = parent.body.signed_execution_payload_header.message.block_hash
+    parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash
+    message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
     return parent_block_hash == message_block_hash
 ```
 
-### Modified `get_ancestor` 
-**Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block. 
+### Modified `get_ancestor`
+**Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
 
 ```python
 def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
     """
-    Returns the beacon block root, the slot and the payload status of the ancestor of the beacon block 
-    with ``root`` at ``slot``. If the beacon block with ``root`` is already at ``slot`` or we are 
-    requesting an ancestor "in the future" it returns its PTC status instead of the actual payload content. 
+    Returns the beacon block root, the slot and the payload status of the ancestor of the beacon block
+    with ``root`` at ``slot``. If the beacon block with ``root`` is already at ``slot`` or we are
+    requesting an ancestor "in the future" it returns its PTC status instead of the actual payload content.
     """
     block = store.blocks[root]
     if block.slot <= slot:
@@ -236,7 +236,7 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
     """
     if node.root == message.root:
         # an attestation for a given root always counts for that root regardless if full or empty
-        # as long as the attestation happened after the requested slot. 
+        # as long as the attestation happened after the requested slot.
         return node.slot <= message.slot
     message_block = store.blocks[message.root]
     if node.slot >= message_block.slot:
@@ -246,7 +246,7 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
 ```
 
 ### New `compute_proposer_boost`
-This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node. 
+This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node.
 ```python
 def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
     if store.proposer_boost_root == Root():
@@ -284,7 +284,7 @@ def compute_withhold_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_reveal_boost`
-This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload. 
+This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload.
 
 ```python
 def compute_reveal_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
@@ -303,7 +303,7 @@ def compute_reveal_boost(store: Store, state: BeaconState, node: ChildNode) -> G
 
 ### Modified `get_weight`
 
-**Note:** `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting. 
+**Note:** `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting.
 
 ```python
 def get_weight(store: Store, node: ChildNode) -> Gwei:
@@ -327,7 +327,7 @@ def get_weight(store: Store, node: ChildNode) -> Gwei:
     return attestation_score + proposer_score + builder_reveal_score + builder_withhold_score
 ```
 
-### Modified `get_head` 
+### Modified `get_head`
 
 **Note:** `get_head` is a modified to use the new `get_weight` function. It returns the `ChildNode` object corresponidng to the head block.
 
@@ -344,13 +344,13 @@ def get_head(store: Store) -> ChildNode:
     while True:
         children = [
             ChildNode(root=root, slot=block.slot, is_payload_present=present) for (root, block) in blocks.items()
-            if block.parent_root == best_child.root and block.slot > best_child.slot and 
+            if block.parent_root == best_child.root and block.slot > best_child.slot and
             (best_child.root == justified_root or is_parent_node_full(store, block) == best_child.is_payload_present)
             for present in (True, False) if root in store.execution_payload_states or not present
         ]
         if len(children) == 0:
             return best_child
-        # if we have children we consider the current head advanced as a possible head 
+        # if we have children we consider the current head advanced as a possible head
         highest_child_slot = max(child.slot for child in children)
         children += [
             ChildNode(root=best_child.root, slot=best_child.slot + 1, is_payload_present=best_child.is_payload_present)
@@ -361,10 +361,10 @@ def get_head(store: Store) -> ChildNode:
         # Ties are then broken by favoring full blocks
         # Ties then broken by favoring block with lexicographically higher root
         new_best_child = max(children, key=lambda child: (
-            get_weight(store, child), 
+            get_weight(store, child),
             blocks[child.root].slot,
-            is_payload_present(store, child.root), 
-            child.is_payload_present, 
+            is_payload_present(store, child.root),
+            child.is_payload_present,
             child.root
         )
         )
@@ -377,7 +377,7 @@ def get_head(store: Store) -> ChildNode:
 
 ### Modified `on_block`
 
-*Note*: The handler `on_block` is modified to consider the pre `state` of the given consensus beacon block depending not only on the parent block root, but also on the parent blockhash. In addition we delay the checking of blob data availability until the processing of the execution payload. 
+*Note*: The handler `on_block` is modified to consider the pre `state` of the given consensus beacon block depending not only on the parent block root, but also on the parent blockhash. In addition we delay the checking of blob data availability until the processing of the execution payload.
 
 ```python
 def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
@@ -390,14 +390,14 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
     # Check if this blocks builds on empty or full parent block
     parent_block = store.blocks[block.parent_root]
-    header = block.body.signed_execution_payload_header.message
-    parent_header = parent_block.body.signed_execution_payload_header.message
+    bid = block.body.signed_execution_payload_bid.message
+    parent_bid = parent_block.body.signed_execution_payload_bid.message
     # Make a copy of the state to avoid mutability issues
     if is_parent_node_full(store, block):
         assert block.parent_root in store.execution_payload_states
         state = copy(store.execution_payload_states[block.parent_root])
     else:
-        assert header.parent_block_hash == parent_header.parent_block_hash
+        assert bid.parent_block_hash == parent_bid.parent_block_hash
         state = copy(store.block_states[block.parent_root])
 
     # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
@@ -450,14 +450,14 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
 ### New `on_execution_payload`
 
-The handler `on_execution_payload` is called when the node receives a `SignedExecutionPayloadEnvelope` to sync. 
+The handler `on_execution_payload` is called when the node receives a `SignedExecutionPayloadEnvelope` to sync.
 
 ```python
 def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
     """
     Run ``on_execution_payload`` upon receiving a new execution payload.
     """
-    envelope = signed_envelope.message 
+    envelope = signed_envelope.message
     # The corresponding beacon block root needs to be known
     assert envelope.beacon_block_root in store.block_states
 
@@ -473,7 +473,7 @@ def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEn
 
     # Add new state for this payload to the store
     store.execution_payload_states[envelope.beacon_block_root] = state
-```   
+```
 
 ### `seconds_into_slot`
 
@@ -498,7 +498,7 @@ def on_tick_per_slot(store: Store, time: uint64) -> None:
     # If this is a new slot, reset store.proposer_boost_root
     if current_slot > previous_slot:
         store.proposer_boost_root = Root()
-    else: 
+    else:
         # Reset the payload boost if this is the attestation time
         if seconds_into_slot(store) >= SECONDS_PER_SLOT // INTERVALS_PER_SLOT:
             store.payload_withhold_boost_root = Root()
@@ -535,7 +535,7 @@ def on_payload_attestation_message(
         assert data.slot == get_current_slot(store)
         # Verify the signature
         assert is_valid_indexed_payload_attestation(
-            state, 
+            state,
             IndexedPayloadAttestation(
                 attesting_indices=[ptc_message.validator_index],
                 data=data,
@@ -546,7 +546,7 @@ def on_payload_attestation_message(
     ptc_index = ptc.index(ptc_message.validator_index)
     ptc_vote = store.ptc_vote[data.beacon_block_root]
     ptc_vote[ptc_index] = data.payload_status
-    
+
     # Only update payload boosts with attestations from a block if the block is for the current slot and it's early
     if is_from_block and data.slot + 1 != get_current_slot(store):
         return
@@ -563,7 +563,7 @@ def on_payload_attestation_message(
         store.payload_withhold_boost_full = is_parent_node_full(store, block)
 ```
 
-### Modified `validate_merge_block` 
+### Modified `validate_merge_block`
 
 The function `validate_merge_block` is modified for test purposes
 
@@ -579,10 +579,10 @@ def validate_merge_block(block: BeaconBlock) -> None:
     if TERMINAL_BLOCK_HASH != Hash32():
         # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
         assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-        assert block.body.signed_execution_payload_header.message.parent_block_hash == TERMINAL_BLOCK_HASH
+        assert block.body.signed_execution_payload_bid.message.parent_block_hash == TERMINAL_BLOCK_HASH
         return
 
-    pow_block = get_pow_block(block.body.signed_execution_payload_header.message.parent_block_hash)
+    pow_block = get_pow_block(block.body.signed_execution_payload_bid.message.parent_block_hash)
     # Check if `pow_block` is available
     assert pow_block is not None
     pow_parent = get_pow_block(pow_block.parent_hash)
@@ -590,6 +590,3 @@ def validate_merge_block(block: BeaconBlock) -> None:
     assert pow_parent is not None
     # Check if `pow_block` is a valid terminal PoW block
     assert is_valid_terminal_pow_block(pow_block, pow_parent)
-
-
-

--- a/specs/_features/eip7732/fork.md
+++ b/specs/_features/eip7732/fork.md
@@ -61,7 +61,7 @@ def compute_fork_version(epoch: Epoch) -> Version:
 
 ### Fork trigger
 
-TBD. This fork is defined for testing purposes, the EIP may be combined with other 
+TBD. This fork is defined for testing purposes, the EIP may be combined with other
 consensus-layer upgrade.
 For now, we assume the condition will be triggered at epoch `EIP7732_FORK_EPOCH`.
 
@@ -113,8 +113,6 @@ def upgrade_to_eip7732(pre: electra.BeaconState) -> BeaconState:
         # Sync
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # Execution-layer
-        latest_execution_payload_header=ExecutionPayloadHeader(),  # [Modified in EIP-7732]
         # Withdrawals
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
@@ -130,6 +128,7 @@ def upgrade_to_eip7732(pre: electra.BeaconState) -> BeaconState:
         pending_partial_withdrawals=pre.pending_partial_withdrawals,
         pending_consolidations=pre.pending_consolidations,
         # ePBS
+        latest_execution_payload_bid=ExecutionPayloadBid(),  # [New in EIP-7732]
         latest_block_hash=pre.latest_execution_payload_header.block_hash,  # [New in EIP-7732]
         latest_full_slot=pre.slot,  # [New in EIP-7732]
         latest_withdrawals_root=Root(),  # [New in EIP-7732]

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -1,10 +1,12 @@
 # EIP-7732 -- Honest Validator
 
-This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork. 
+This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork.
 
+## Table of Contents
+
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents** 
 
 - [Validator assignment](#validator-assignment)
   - [Lookahead](#lookahead)
@@ -12,13 +14,14 @@ This document represents the changes and additions to the Honest validator guide
   - [Attestation](#attestation)
   - [Sync Committee participations](#sync-committee-participations)
   - [Block proposal](#block-proposal)
-    - [Constructing the new `signed_execution_payload_header` field in  `BeaconBlockBody`](#constructing-the-new-signed_execution_payload_header-field-in--beaconblockbody)
-    - [Constructing the new `payload_attestations` field in  `BeaconBlockBody`](#constructing-the-new-payload_attestations-field-in--beaconblockbody)
+    - [Constructing the new `signed_execution_payload_bid` field in `BeaconBlockBody`](#constructing-the-new-signed_execution_payload_bid-field-in-beaconblockbody)
+    - [Constructing the new `payload_attestations` field in `BeaconBlockBody`](#constructing-the-new-payload_attestations-field-in-beaconblockbody)
     - [Blob sidecars](#blob-sidecars)
   - [Payload timeliness attestation](#payload-timeliness-attestation)
     - [Constructing a payload attestation](#constructing-a-payload-attestation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Validator assignment
 
@@ -33,7 +36,7 @@ def get_ptc_assignment(
         validator_index: ValidatorIndex) -> Optional[Slot]:
     """
     Returns the slot during the requested epoch in which the validator with index `validator_index`
-    is a member of the PTC. Returns None if no assignment is found. 
+    is a member of the PTC. Returns None if no assignment is found.
     """
     next_epoch = Epoch(get_current_epoch(state) + 1)
     assert epoch <= next_epoch
@@ -49,57 +52,57 @@ def get_ptc_assignment(
 
 [New in EIP-7732]
 
-`get_ptc_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should plan for future assignments by noting their assigned PTC slot. 
+`get_ptc_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should plan for future assignments by noting their assigned PTC slot.
 
 ## Beacon chain responsibilities
 
 All validator responsibilities remain unchanged other than the following:
 
-- Proposers are no longer required to broadcast `BlobSidecar` objects, as this becomes a builder's duty. 
-- Some validators are selected per slot to become PTC members, these validators must broadcast `PayloadAttestationMessage` objects during the assigned slot before the deadline of `3 * SECONDS_PER_SLOT // INTERVALS_PER_SLOT` seconds into the slot. 
+- Proposers are no longer required to broadcast `BlobSidecar` objects, as this becomes a builder's duty.
+- Some validators are selected per slot to become PTC members, these validators must broadcast `PayloadAttestationMessage` objects during the assigned slot before the deadline of `3 * SECONDS_PER_SLOT // INTERVALS_PER_SLOT` seconds into the slot.
 
 ### Attestation
 
-Attestation duties are not changed for validators, however the attestation deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`. 
+Attestation duties are not changed for validators, however the attestation deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`.
 
 ### Sync Committee participations
 
-Sync committee duties are not changed for validators, however the submission deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`. 
+Sync committee duties are not changed for validators, however the submission deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`.
 
 
 ### Block proposal
 
 Validators are still expected to propose `SignedBeaconBlock` at the beginning of any slot during which `is_proposer(state, validator_index)` returns `true`. The mechanism to prepare this beacon block and related sidecars differs from previous forks as follows
 
-#### Constructing the new `signed_execution_payload_header` field in  `BeaconBlockBody`
+#### Constructing the new `signed_execution_payload_bid` field in `BeaconBlockBody`
 
-To obtain `signed_execution_payload_header`, a block proposer building a block on top of a `state` must take the following actions:
-* Listen to the `execution_payload_header` gossip global topic and save an accepted `signed_execution_payload_header` from a builder. Proposer MAY obtain these signed messages by other off-protocol means. 
-* The `signed_execution_payload_header` must satisfy the verification conditions found in `process_execution_payload_header`, that is 
-    - The header signature must be valid
-    - The builder balance can cover the header value
-    - The header slot is for the proposal block slot
-    - The header parent block hash equals the state's `latest_block_hash`. 
-    - The header parent block root equals the current block's `parent_root`.
-* Select one bid and set `body.signed_execution_payload_header = signed_execution_payload_header`
+To obtain `signed_execution_payload_bid`, a block proposer building a block on top of a `state` must take the following actions:
+* Listen to the `execution_payload_bid` gossip global topic and save an accepted `signed_execution_payload_bid` from a builder. Proposer MAY obtain these signed messages by other off-protocol means.
+* The `signed_execution_payload_bid` must satisfy the verification conditions found in `process_execution_payload_bid`, that is
+    - The bid signature must be valid
+    - The builder balance can cover the bid value
+    - The bid slot is for the proposal block slot
+    - The bid parent block hash equals the state's `latest_block_hash`.
+    - The bid parent block root equals the current block's `parent_root`.
+* Select one bid and set `body.signed_execution_payload_bid = signed_execution_payload_bid`
 
-#### Constructing the new `payload_attestations` field in  `BeaconBlockBody`
+#### Constructing the new `payload_attestations` field in `BeaconBlockBody`
 
-Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included in the block. The validator will have to 
-* Listen to the `payload_attestation_message` gossip global topic 
+Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included in the block. The validator will have to
+* Listen to the `payload_attestation_message` gossip global topic
 * The payload attestations added must satisfy the verification conditions found in payload attestation gossip validation and payload attestation processing. This means
     - The `data.beacon_block_root` corresponds to `block.parent_root`.
-    - The slot of the parent block is exactly one slot before the proposing slot. 
-    - The signature of the payload attestation data message verifies correctly. 
-* The proposer needs to aggregate all payload attestations with the same data into a given `PayloadAttestation` object. For this it needs to fill the `aggregation_bits` field by using the relative position of the validator indices with respect to the PTC that is obtained from `get_ptc(state, block_slot - 1)`. 
-* The proposer should only include payload attestations that are consistent with the current block they are proposing. That is, if the previous block had a payload, they should only include attestations with `payload_status = PAYLOAD_PRESENT`. Proposers are penalized for attestations that are not-consistent with their view. 
+    - The slot of the parent block is exactly one slot before the proposing slot.
+    - The signature of the payload attestation data message verifies correctly.
+* The proposer needs to aggregate all payload attestations with the same data into a given `PayloadAttestation` object. For this it needs to fill the `aggregation_bits` field by using the relative position of the validator indices with respect to the PTC that is obtained from `get_ptc(state, block_slot - 1)`.
+* The proposer should only include payload attestations that are consistent with the current block they are proposing. That is, if the previous block had a payload, they should only include attestations with `payload_status = PAYLOAD_PRESENT`. Proposers are penalized for attestations that are not-consistent with their view.
 
 #### Blob sidecars
 The blob sidecars are no longer broadcast by the validator, and thus their construction is not necessary. This deprecates the corresponding sections from the honest validator guide in the Electra fork, moving them, albeit with some modifications, to the [honest Builder guide](./builder.md)
 
 ### Payload timeliness attestation
 
-Some validators are selected to submit payload timeliness attestations. Validators should call `get_ptc_assignment` at the beginning of an epoch to be prepared to submit their PTC attestations during the next epoch. 
+Some validators are selected to submit payload timeliness attestations. Validators should call `get_ptc_assignment` at the beginning of an epoch to be prepared to submit their PTC attestations during the next epoch.
 
 A validator should create and broadcast the `payload_attestation_message` to the global execution attestation subnet not after `SECONDS_PER_SLOT * 3 / INTERVALS_PER_SLOT` seconds since the start of `slot`
 
@@ -109,9 +112,9 @@ If a validator is in the payload attestation committee for the current slot (as 
 according to the logic in `get_payload_attestation_message` below and broadcast it not after  `SECONDS_PER_SLOT * 3 / INTERVALS_PER_SLOT` seconds since the start of the slot, to the global `payload_attestation_message` pubsub topic.
 
 The validator creates `payload_attestation_message` as follows:
-* If the validator has not seen any beacon block for the assigned slot, do not submit a payload attestation. It will be ignored anyway. 
+* If the validator has not seen any beacon block for the assigned slot, do not submit a payload attestation. It will be ignored anyway.
 * Set `data.beacon_block_root` be the HTR of the beacon block seen for the assigned slot
-* Set `data.slot` to be the assigned slot. 
+* Set `data.slot` to be the assigned slot.
 * Set `data.payload_status` as follows
     - If a `SignedExecutionPayloadEnvelope` has been seen referencing the block `data.beacon_block_root` and the envelope has `payload_withheld = False`,  set to `PAYLOAD_PRESENT`.
     - If a `SignedExecutionPayloadEnvelope` has been seen referencing the block `data.beacon_block_root` and the envelope has `payload_withheld = True`,  set to `PAYLOAD_WITHHELD`.
@@ -119,7 +122,7 @@ The validator creates `payload_attestation_message` as follows:
 * Set `payload_attestation_message.validator_index = validator_index` where `validator_index` is the validator chosen to submit. The private key mapping to `state.validators[validator_index].pubkey` is used to sign the payload timeliness attestation.
 * Sign the `payload_attestation_message.data` using the helper `get_payload_attestation_message_signature`.
 
-Notice that the attester only signs the `PayloadAttestationData` and not the `validator_index` field in the message. Proposers need to aggregate these attestations as described above. 
+Notice that the attester only signs the `PayloadAttestationData` and not the `validator_index` field in the message. Proposers need to aggregate these attestations as described above.
 
 ```python
 def get_payload_attestation_message_signature(
@@ -129,6 +132,4 @@ def get_payload_attestation_message_signature(
     return bls.Sign(privkey, signing_root)
 ```
 
-**Remark** Validators do not need to check the full validity of the `ExecutionPayload` contained in within the envelope, but the checks in the [P2P guide](./p2p-interface.md) should pass for the `SignedExecutionPayloadEnvelope`. 
-
-
+**Remark** Validators do not need to check the full validity of the `ExecutionPayload` contained in within the envelope, but the checks in the [P2P guide](./p2p-interface.md) should pass for the `SignedExecutionPayloadEnvelope`.


### PR DESCRIPTION
For clarity and less ambiguity, rename `execution_payload_header` and related identifiers to `execution_payload_bid` where they refer to a pending but not yet fulfilled builder bid. Builders are not submitting actual execution block headers, we should not mix the bid concept with the header concept.

This also removes naming clashes from EL nomenclature where block header refers to the EL block header, and also with CL light client naming where `LightClientHeader` also points to CL / EL block headers that where actually integrated into the chain.